### PR TITLE
Adicionando Memo na listagem dos pokémons e removendo importação não utilizada

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo } from "react";
+import { useId } from "react";
 
 // types
 import type { TInput } from "./types";
@@ -8,7 +8,9 @@ const Input = ({ label, className, ...rest }: TInput) => {
   const inputId = useId();
 
   return (
-    <div className={`${className} flex flex-col justify-start items-start w-full gap-2`}>
+    <div
+      className={`${className} flex flex-col justify-start items-start w-full gap-2`}
+    >
       {label && (
         <label className="" htmlFor={inputId}>
           {label}

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,20 +1,24 @@
+import { memo } from "react";
+
 // types
-import type { TListProps } from './types';
+import type { TListProps } from "./types";
 
 // components
-import { PokeCard } from '..';
+import { PokeCard } from "..";
 
 // ::
 const List = ({ list }: TListProps) => {
   if (!list) return null;
 
   return (
-    <div className='transition-colors bg-fixed animate-infinityParallax pattern-cross pattern-illusion-2 dark:pattern-illusion-4 dark:pattern-bg-illusion-5 pattern-bg-illusion-3 pattern-opacity-100 pattern-size-6 flex md:flex-row flex-col flex-wrap gap-2 items-start justify-center bg-illusion-5 border border-illusion-3 rounded-md shadow-sm p-10'>
-      {list.pages?.map((page) => page.results.map((pokemon) => (
-        <PokeCard url={pokemon.url} key={pokemon.url} />
-      )))}
+    <div className="transition-colors bg-fixed animate-infinityParallax pattern-cross pattern-illusion-2 dark:pattern-illusion-4 dark:pattern-bg-illusion-5 pattern-bg-illusion-3 pattern-opacity-100 pattern-size-6 flex md:flex-row flex-col flex-wrap gap-2 items-start justify-center bg-illusion-5 border border-illusion-3 rounded-md shadow-sm p-10">
+      {list.pages?.map((page) =>
+        page.results.map((pokemon) => (
+          <PokeCard url={pokemon.url} key={pokemon.url} />
+        ))
+      )}
     </div>
-  )
-}
+  );
+};
 
-export default List;
+export default memo(List);


### PR DESCRIPTION
Caso o usuário tente pesquisar por um pokémon no input quando tem muitos pokémons carregados na tela, a aplicação fica muito lenta por estar renderizando novamente a lista inteira de pokémons.
Como solução para o problema utilizei o hook do react Memo na exportação da lista.

Também removi uma importação que não estava sendo utilizada.

